### PR TITLE
Bugfix when source and target have the same resolution

### DIFF
--- a/brainregister/__init__.py
+++ b/brainregister/__init__.py
@@ -937,7 +937,7 @@ class BrainRegister(object):
         elif t2s_ratio < s2t_ratio:
             self.downsampling_img = 'target'
         else: # source and target are same size!
-            self.downsampling_img = 'none' # so do NO DOWNSAMPLING!
+            self.downsampling_img = 'source' # so use either of them
         
         # initialise bools for prefiltering
         # use to determine whether the src->tar or tar->src prefiltering has been applied

--- a/brainregister/__init__.py
+++ b/brainregister/__init__.py
@@ -3088,18 +3088,18 @@ class BrainRegister(object):
                                                 self.src_tar_filter_pipeline )
                     
                 
-                if self.target_template_img_ds_filt != None:
+                if self.target_template_img_filt != None:
                     if self.src_tar_prefiltered: # already correctly filtered!
-                        print('    ds target template') # just log as if filtering took place
+                        print('    target template') # just log as if filtering took place
                     else: # filter correctly
-                        print('    ds target template')
-                        self.target_template_img_ds_filt = self.apply_adaptive_filter(
-                                                    self.target_template_img_ds, 
+                        print('    target template')
+                        self.target_template_img_filt = self.apply_adaptive_filter(
+                                                    self.target_template_img,
                                                     self.src_tar_filter_pipeline )
                 else: # no filtered image exists!
-                    print('    ds target template')
-                    self.target_template_img_ds_filt = self.apply_adaptive_filter(
-                                                self.target_template_img_ds, 
+                    print('    target template')
+                    self.target_template_img_filt = self.apply_adaptive_filter(
+                                                self.target_template_img,
                                                 self.src_tar_filter_pipeline )
                 
                 # set bools to indicate filtering

--- a/brainregister/__init__.py
+++ b/brainregister/__init__.py
@@ -937,7 +937,7 @@ class BrainRegister(object):
         elif t2s_ratio < s2t_ratio:
             self.downsampling_img = 'target'
         else: # source and target are same size!
-            self.downsampling_img = 'source' # so use either of them
+            self.downsampling_img = 'none' # so do NO DOWNSAMPLING!
         
         # initialise bools for prefiltering
         # use to determine whether the src->tar or tar->src prefiltering has been applied


### PR DESCRIPTION
Solves #2 

It might be a dirty trick. Maybe just copying the original data would be better than "resampling" to the same scale.